### PR TITLE
make microcomp_db an installable executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ er_diagram.pdf
 
 # Don't include notebook local files
 .ipynb_checkpoints/
+
+# Distribution files
+*.egg-info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,25 @@
+[project]
+name = "microcomp_db"
+version = "0.1"
+authors = [{ name = "Julia Monserrat Relaño" }]
+description = "A database to assist engineering bacterial microcompartment"
+readme = "README.md"
+requires-python = ">=3.13"
+license = "MIT"
+license-files = ["LICENSE"]
+dependencies = ["sqlalchemy", "click"]
+
 [mypy]
 plugins = "sqlalchemy.ext.mypy.plugin"
+
+[tool.setuptools.packages.find]
+include = ["scripts"]
+
+[project.scripts]
+"microcomp_db" = "scripts.microcomp_db:main"
+
+[project.urls]
+homepage = "https://github.com/monserrj/BMC-database"
+source = "https://github.com/monserrj/BMC-database"
+issues = "https://github.com/monserrj/BMC-database/issues"
+documentation = "https://github.com/monserrj/BMC-database/blob/master/docs/README.md"

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+# scripts module for BMC-database

--- a/scripts/db.py
+++ b/scripts/db.py
@@ -15,7 +15,7 @@ from pathlib import Path  # for type hints
 from typing import Optional
 
 
-from enums import DatabaseType, StructProtType, ModificationType, enum_from_str
+from .enums import DatabaseType, StructProtType, ModificationType, enum_from_str
 
 # Import  SQLAlchemy classes needed with a declarative approach.
 from sqlalchemy import (

--- a/scripts/file_and_data.py
+++ b/scripts/file_and_data.py
@@ -8,7 +8,7 @@ followed and explanations kept to help following through
 import logging
 from pathlib import Path
 
-from db import (
+from .db import (
     Xdatabase,
     add_protein,
     add_cds,
@@ -21,7 +21,7 @@ from db import (
     DATABASE_TARGETS,
     add_modification,
 )
-from readfile import read_file
+from .readfile import read_file
 
 # To make boolean values from the csv true booleans:
 def parse_bool(value):

--- a/scripts/microcomp_db.py
+++ b/scripts/microcomp_db.py
@@ -16,9 +16,9 @@ import click
 
 # Import the database file, csv and the data addition file to create
 # and populate database
-from db import create_db, get_session
-from readfile import read_file
-from file_and_data import link_db_csv
+from .db import create_db, get_session
+from .readfile import read_file
+from .file_and_data import link_db_csv
 
 
 @click.command()


### PR DESCRIPTION
Add info to pyproject.toml to make microcomp_db an executable application, and make internal imports consistent
